### PR TITLE
Changed logic of the hashcat.ps1 script in hashcat package trying to fix: #65.

### DIFF
--- a/automatic/hashcat/tools/chocolateyinstall.ps1
+++ b/automatic/hashcat/tools/chocolateyinstall.ps1
@@ -12,5 +12,13 @@ $packageArgs = @{
 
 Install-ChocolateyZipPackage @packageArgs
 
+
 $psfile     = Join-Path "$toolsDir" "hashcat.ps1"
+
+# resolve installation Path during installation where admin user has access the
+# $env:ChocolateyToolsLocation variable
+$hashcatDir = (Get-ChildItem "$env:ChocolateyToolsLocation\hashcat*" -Directory).FullName
+# Insert installation path into Powershell-Script
+(Get-Content $psfile -Raw).Replace('{{HASHCAT_DIR}}', $hashcatDir) | Set-Content $psfile
+
 Install-ChocolateyPowershellCommand -PackageName "hashcat" -PSFileFullPath "$psfile"

--- a/automatic/hashcat/tools/hashcat.ps1
+++ b/automatic/hashcat/tools/hashcat.ps1
@@ -1,14 +1,10 @@
-$hashcatDir = (Get-ChildItem "$env:ChocolateyToolsLocation\hashcat*" -Directory).FullName
+# replaced by (Get-ChildItem "$env:ChocolateyToolsLocation\hashcat*" -Directory).FullName during installation
+$hashcatDir = '{{HASHCAT_DIR}}'
 
 Push-Location $hashcatDir
 
 $argumentsString = $args -join ' '                          # Join arguments to a string
 
-if([Environment]::Is64BitProcess) {                         # If 64-bit
-  Invoke-Expression ".\hashcat64.exe $argumentsString"      # Invoke 64-bit executable with parameters
-}
-else {                                                      # If not 64-bit
-  Invoke-Expression ".\hashcat32.exe $argumentsString"      # Invoke 32-bit executable with parameters
-}
+Invoke-Expression ".\hashcat.exe $argumentsString"      # Invoke executable with parameters
 
 Pop-Location


### PR DESCRIPTION
I tried to fix the issue by removing the architecture specific calls and replacing them with a single call to hashcat.exe, which is the only PE file i can find in new hashcat releases.

I also tried my best to change the $hashcatDir var in the script to fix the second powershell error shown in the issue screenshot.
The error is due to the path: C:\tools\hashcat-7.1.2 not being in quotes in the hashcat.ps1 file.

When i looked at the hascat.ps1 file in the repo i noticed, that it was quite different from the one installed on my maschine.
I am unsure why that is, perhaps I missed something...

Anyway i tired to use the version in the repository and found out that it wouldnt work for me since the environment var "ChocolateyToolsLocation" is in the admin system variables, so normal user trying to run hashcat.ps1 will get an empty string as the hashcatDir, resulting in failure.

But i also didnt want to hardcode the default path "C:\tools" into the hashcat.ps1 file, since that would break it for users with a nondefault installation path.

So i tried to combine it by having the installer script , which is ran as admin and can access the env var, insert the correct path into the hashcat.ps1 script during installation.

I havent been able to test a full installation of the package with this logic, but the logic itself seems to work:
<img width="1346" height="415" alt="Screenshot 2026-04-04 144648" src="https://github.com/user-attachments/assets/4a3b440b-f466-4988-b0da-f14e7f99c921" />

Thank you for you hard work maintaining these chocolatey packages :).