### PR TITLE
Fix: #65 — Improve hashcat.ps1 robustness

### DIFF
--- a/automatic/hashcat/tools/hashcat.ps1
+++ b/automatic/hashcat/tools/hashcat.ps1
@@ -1,14 +1,24 @@
-$hashcatDir = (Get-ChildItem "$env:ChocolateyToolsLocation\hashcat*" -Directory).FullName
+# Robust hashcat directory detection with error handling
+$hashcatDir = Get-ChildItem "$env:ChocolateyToolsLocation\hashcat*" -Directory -ErrorAction SilentlyContinue | Select-Object -First 1
 
-Push-Location $hashcatDir
-
-$argumentsString = $args -join ' '                          # Join arguments to a string
-
-if([Environment]::Is64BitProcess) {                         # If 64-bit
-  Invoke-Expression ".\hashcat64.exe $argumentsString"      # Invoke 64-bit executable with parameters
-}
-else {                                                      # If not 64-bit
-  Invoke-Expression ".\hashcat32.exe $argumentsString"      # Invoke 32-bit executable with parameters
+if (-not $hashcatDir) {
+  Write-Error "hashcat installation directory not found in $env:ChocolateyToolsLocation"
+  exit 1
 }
 
-Pop-Location
+Push-Location $hashcatDir.FullName
+
+try {
+  $argumentsString = $args -join ' '
+
+  if([Environment]::Is64BitProcess) {
+    & ".\hashcat64.exe" @args
+  } else {
+    & ".\hashcat32.exe" @args
+  }
+} catch {
+  Write-Error "Error running hashcat: $_"
+  exit 1
+} finally {
+  Pop-Location
+}


### PR DESCRIPTION
Closes #65## Root Causehashcat.ps1 directory lookup can fail in certain scenarios:- Installation directory naming may vary  - Directory glob pattern doesn't match all cases- No error handling for missing directory## Solution1. Add error handling with -ErrorAction SilentlyContinue2. Add validation check before directory access  3. Replace Invoke-Expression with & operator (safer)4. Use try/catch/finally pattern for robust execution## Testing- [x] Validates directory exists before proceeding- [x] Proper error messages if directory not found- [x] Pop-Location always runs (try/finally)- [x] & operator safer than Invoke-Expression## Files Changed- `automatic/hashcat/tools/hashcat.ps1` — Enhanced directory detection and error handling