### PR TITLE
fix(git-annex): force AU resubmit via version 0.0 + -NoCheckChocoVersion

### DIFF
--- a/automatic/git-annex/git-annex.nuspec
+++ b/automatic/git-annex/git-annex.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>git-annex</id>
-    <version>10.20241031.0</version>
+    <version>0.0</version>
     <title>git-annex</title>
     <authors>Joey Hess</authors>
     <owners>tunisiano</owners>

--- a/automatic/git-annex/update.ps1
+++ b/automatic/git-annex/update.ps1
@@ -34,4 +34,4 @@ function global:au_GetLatest {
 	return $Latest
 }
 
-update -ChecksumFor none
+update -ChecksumFor none -NoCheckChocoVersion


### PR DESCRIPTION
## Summary

The `git-annex` package is absent from the Chocolatey community repository. To force AU to re-publish it regardless of the version currently registered on chocolatey.org, two changes are applied:

- `git-annex.nuspec`: version set to `0.0` so AU sees it as outdated and triggers a push.
- `update.ps1`: `-NoCheckChocoVersion` added to `update -ChecksumFor none` so AU skips the version comparison against the community feed.

Once AU successfully re-submits the package and it passes validation on chocolatey.org, a follow-up PR will remove `-NoCheckChocoVersion` (it is a one-time re-push flag, not a permanent setting).

---
_Generated by [Claude Code](https://claude.ai/code/session_0191qKSGMvE57BC4YULat79h)_