### PR TITLE
fix(ci): fix broken gist-update step in Package Updater workflow

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -137,7 +137,7 @@ jobs:
             unsaved_changes.patch
             au_temp.7z
             update_info.xml
-            Update-AUPackages.md
+            au/Update-AUPacakges.md
             eventlogs.txt
             **/*.nupkg
           retention-days: 5
@@ -145,19 +145,20 @@ jobs:
 
       - name: Update gist with report
         if: always()
+        shell: pwsh
         env:
           GIST_ID: ${{ env.gist_id }}
           GIST_TOKEN: ${{ secrets.AU_GITHUB_API_KEY }}
-          REPORT_PATH: Update-AUPackages.md
+          REPORT_PATH: au/Update-AUPacakges.md
         run: |
-          pwsh -NoProfile -Command "
-            $gistId = '${{ env.gist_id }}';
-            $token = '${{ secrets.AU_GITHUB_API_KEY }}';
-            $file = 'Update-AUPackages.md';
-            if (Test-Path $file) {
-              $content = Get-Content $file -Raw -Encoding UTF8;
-              $body = @{ files = @{ 'Update-AUPackages.md' = @{ content = $content } } } | ConvertTo-Json -Depth 10;
-              Invoke-RestMethod -Uri "https://api.github.com/gists/$gistId" -Method PATCH -Headers @{ Authorization = "token $token"; Accept = 'application/vnd.github+json' } -Body $body -ContentType 'application/json';
-              Write-Host "Gist updated: $gistId";
-            } else { Write-Warning "Report file not found: $file" }
-          "
+          $gistId = $env:GIST_ID
+          $token = $env:GIST_TOKEN
+          $file = $env:REPORT_PATH
+          if (Test-Path $file) {
+            $content = Get-Content $file -Raw -Encoding UTF8
+            $body = @{ files = @{ 'Update-AUPackages.md' = @{ content = $content } } } | ConvertTo-Json -Depth 10
+            Invoke-RestMethod -Uri "https://api.github.com/gists/$gistId" -Method PATCH -Headers @{ Authorization = "token $token"; Accept = 'application/vnd.github+json' } -Body $body -ContentType 'application/json'
+            Write-Host "Gist updated: $gistId"
+          } else {
+            Write-Warning "Report file not found: $file"
+          }


### PR DESCRIPTION
## Summary

The `Package Updater` workflow (`.github/workflows/updater.yml`) has been failing on every scheduled run since at least 2026-07-24 (e.g. [run 30235794690](https://github.com/tunisiano187/choco-packages/actions/runs/30235794690)) with:

```
ParserError:
Missing statement after '=' in hash literal.
##[error]Process completed with exit code 1.
```

Root causes:

- The "Update gist with report" step wraps a `pwsh -NoProfile -Command "..."` script inside a **double-quoted string**, but the step itself runs under the job's default `shell: powershell` (Windows PowerShell). The outer shell interpolates `$content`, `$gistId`, `$token`, etc. *before* the string is ever handed to `pwsh`, which mangles the script and throws the parser error above on every run.
- Even once parsing succeeds, the step (and the artifact-upload step) reference the report as `Update-AUPackages.md` at the repo root, but the AU module actually writes it to `au/Update-AUPacakges.md` (note AU's own upstream typo). So the report was never actually picked up by either step.

## Changes

- Set `shell: pwsh` explicitly on the "Update gist with report" step and rewrite the script to read `$env:GIST_ID` / `$env:GIST_TOKEN` / `$env:REPORT_PATH` directly, removing the broken nested-quoting invocation.
- Fix the report path used by both the artifact upload step and the gist-update step to `au/Update-AUPacakges.md`, matching what AU actually generates.

This is an infrastructure/workflow fix only — no package files were touched.

## Test plan

- [x] Validated the workflow YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/updater.yml'))"`)
- [ ] Confirm the next scheduled/manual run of `Package Updater` completes without the ParserError and that the gist report updates successfully

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXPbvZUuDoPzwjEZxhfSd9)_