### PR TITLE
fix(ci): don't fail Package Updater run when gist report update fails

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -157,8 +157,12 @@ jobs:
           if (Test-Path $file) {
             $content = Get-Content $file -Raw -Encoding UTF8
             $body = @{ files = @{ 'Update-AUPackages.md' = @{ content = $content } } } | ConvertTo-Json -Depth 10
-            Invoke-RestMethod -Uri "https://api.github.com/gists/$gistId" -Method PATCH -Headers @{ Authorization = "token $token"; Accept = 'application/vnd.github+json' } -Body $body -ContentType 'application/json'
-            Write-Host "Gist updated: $gistId"
+            try {
+              Invoke-RestMethod -Uri "https://api.github.com/gists/$gistId" -Method PATCH -Headers @{ Authorization = "token $token"; Accept = 'application/vnd.github+json' } -Body $body -ContentType 'application/json' -ErrorAction Stop
+              Write-Host "Gist updated: $gistId"
+            } catch {
+              Write-Warning "Failed to update gist $gistId (this is a best-effort report step; it does not affect the actual package update): $_"
+            }
           } else {
             Write-Warning "Report file not found: $file"
           }


### PR DESCRIPTION
## Summary
- The "Update gist with report" step in `.github/workflows/updater.yml` (`if: always()`) PATCHes gist `94c2ec0efd8f0d199af1ae9914bec446` with the run report, but that request has returned `404 Not Found` on every scheduled run for several days running (runs #1742, #1746, #1750, ...), failing the whole job even though the actual package update and `git push` already succeeded earlier in the same run.
- Wrap the `Invoke-RestMethod` call in `try/catch` so a failure to update this best-effort report gist no longer fails the run.

## Why
The prior fix in this area (PR #73, "fix broken gist-update step") addressed a different symptom but didn't add error handling around the actual API call, so the same 404 kept failing the job on every scheduled run since (confirmed via job logs on runs 30261205034, 30351850685, 30475116374 — all failing with `Invoke-RestMethod: ... "message": "Not Found"` at the same line).

## Test plan
- [ ] Confirm the next scheduled `Package Updater` run completes successfully (or at least doesn't fail solely due to this step) even if the gist PATCH still 404s.
- [ ] If the gist ID is meant to point somewhere real, verify/update `env.gist_id` separately — this PR only stops it from being a hard failure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXPbvZUuDoPzwjEZxhfSd9)_