### PR TITLE
ci: use chocolatey-au develop branch instead of master

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Set au version to use or omit to use the latest. Specify branch name to use development version from Github
-  au_version: master
+  au_version: develop
   au_push: true
   # Use 1 to test all, or N to split testing into N groups
   au_test_groups: 1


### PR DESCRIPTION
## Summary
- Point the `Package Updater` workflow at the `develop` branch of [chocolatey-community/chocolatey-au](https://github.com/chocolatey-community/chocolatey-au) instead of `master`, by changing the `au_version` env var (`.github/workflows/updater.yml`).
- `au_version` is the parameter passed to `Install-AU.ps1`, which does `git checkout $Version` on the already-cloned repo after build — it's the value that actually determines which branch ends up installed, regardless of what the initial `git clone` checks out. The workflow's own inline comment confirms this is the intended mechanism ("Specify branch name to use development version from Github").

## Test plan
- [ ] Manually trigger the `Package Updater` workflow (`workflow_dispatch`) and confirm the "Install Dependencies" step builds AU from the `develop` branch without errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GXPbvZUuDoPzwjEZxhfSd9)_